### PR TITLE
Object 메모리 할당 기능 수정 및 LOGFMT 개선

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Rotator.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Rotator.h
@@ -41,6 +41,11 @@ struct FRotator
     FRotator operator*(float Scalar) const;
     FRotator& operator*=(float Scalar);
 
+    friend FRotator operator*(float Scalar, const FRotator& Rotator)
+    {
+        return Rotator * Scalar; // 기존 멤버 함수 재활용
+    }
+
     FRotator operator/(const FRotator& Other) const;
     FRotator operator/(float Scalar) const;
     FRotator& operator/=(float Scalar);
@@ -79,9 +84,4 @@ inline FArchive& operator<<(FArchive& Ar, FRotator& R)
 {
     Ar << R.Pitch << R.Yaw << R.Roll;
     return Ar;
-}
-
-inline FRotator operator*(float Scalar, const FRotator& Rotator)
-{
-    return Rotator * Scalar; // 기존 멤버 함수 재활용
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/Object.h
@@ -71,35 +71,16 @@ public:
     }
 
 public:
-    void* operator new(size_t size)
+    FVector4 EncodeUUID() const
     {
-        UE_LOG(ELogLevel::Display, "UObject Created : %d", size);
+        FVector4 Result;
 
-        void* RawMemory = FPlatformMemory::Malloc<EAT_Object>(size);
-        UE_LOG(
-            ELogLevel::Display,
-            "TotalAllocationBytes : %d, TotalAllocationCount : %d",
-            FPlatformMemory::GetAllocationBytes<EAT_Object>(),
-            FPlatformMemory::GetAllocationCount<EAT_Object>()
-        );
-        return RawMemory;
-    }
+        Result.X = static_cast<float>(UUID % 0xFF);
+        Result.Y = static_cast<float>(UUID >> 8 & 0xFF);
+        Result.Z = static_cast<float>(UUID >> 16 & 0xFF);
+        Result.W = static_cast<float>(UUID >> 24 & 0xFF);
 
-    void operator delete(void* ptr, size_t size)
-    {
-        UE_LOG(ELogLevel::Display, "UObject Deleted : %d", size);
-        FPlatformMemory::Free<EAT_Object>(ptr, size);
-    }
-
-    FVector4 EncodeUUID() const {
-        FVector4 result;
-
-        result.X = UUID % 0xFF;
-        result.Y = UUID >> 8 & 0xFF;
-        result.Z = UUID >> 16 & 0xFF;
-        result.W = UUID >> 24 & 0xFF;
-
-        return result;
+        return Result;
     }
 
     virtual void SerializeAsset(FArchive& Ar) {}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectFactory.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectFactory.h
@@ -2,7 +2,6 @@
 #include "EngineStatics.h"
 #include "Object.h"
 #include "Class.h"
-#include "Define.h"
 #include "UObjectArray.h"
 #include "UserInterface/Console.h"
 
@@ -12,21 +11,23 @@ public:
     static UObject* ConstructObject(UClass* InClass, UObject* InOuter, FName InName = NAME_None)
     {
         const uint32 Id = UEngineStatics::GenUUID();
-        FString Name = InClass->GetName() + "_" + std::to_string(Id);
+        FName Name = FString::Printf(TEXT("%s_%d"), *InClass->GetName(), Id);
+
         if (InName != NAME_None)
         {
-            Name = InName.ToString();
+            Name = InName;
         }
 
         UObject* Obj = InClass->ClassCTOR();
-        Obj->ClassPrivate = InClass;
-        Obj->NamePrivate = Name;
         Obj->UUID = Id;
+        Obj->NamePrivate = Name;
+        Obj->ClassPrivate = InClass;
         Obj->OuterPrivate = InOuter;
 
         GUObjectArray.AddObject(Obj);
 
-        UE_LOG(ELogLevel::Display, "Created New Object : %s", *Name);
+        UE_LOGFMT(ELogLevel::Display, "Created Object: {}, Size: {}", Obj->GetName(), InClass->GetClassSize());
+
         return Obj;
     }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/ObjectMacros.h
@@ -39,7 +39,7 @@ public: \
             static_cast<uint32>(alignof(TClass)), \
             TSuperClass::StaticClass(), \
             []() -> UObject* { \
-                void* RawMemory = FPlatformMemory::Malloc<EAT_Object>(sizeof(TClass)); \
+                void* RawMemory = FPlatformMemory::AlignedMalloc<EAT_Object>(sizeof(TClass), alignof(TClass)); \
                 ::new (RawMemory) TClass; \
                 return static_cast<UObject*>(RawMemory); \
             } \

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/CoreUObject/UObject/UObjectArray.cpp
@@ -1,4 +1,6 @@
 #include "UObjectArray.h"
+
+#include "Class.h"
 #include "Object.h"
 #include "UObjectHash.h"
 
@@ -20,7 +22,14 @@ void FUObjectArray::ProcessPendingDestroyObjects()
 {
     for (UObject* Object : PendingDestroyObjects)
     {
-        delete Object;
+        const UClass* Class = Object->GetClass();
+        std::string ObjectName = Object->GetName().ToAnsiString();
+        const uint32 ObjectSize = Class->GetClassSize();
+
+        std::destroy_at(Object);
+        FPlatformMemory::AlignedFree<EAT_Object>(Object, ObjectSize);
+
+        UE_LOGFMT(ELogLevel::Display, "Deleted Object: {}, Size: {}", ObjectName, ObjectSize);
     }
     PendingDestroyObjects.Empty();
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/AssetManager.cpp
@@ -478,7 +478,7 @@ bool UAssetManager::SerializeVersion(FArchive& Ar)
 
     if (FileVersion != Version)
     {
-        UE_LOG_FMT(ELogLevel::Error, "MeshAsset version mismatch: {} != {}", FileVersion, Version);
+        UE_LOGFMT(ELogLevel::Error, "MeshAsset version mismatch: {} != {}", FileVersion, Version);
         return false;
     }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
@@ -7,22 +7,18 @@
 #include "ImGui/imgui.h"
 #include "PropertyEditor/IWindowToggleable.h"
 
-static consteval const char* GetFileName(const char* Path)
+static consteval std::string_view GetFileName(std::string_view PathView)
 {
-    const char* Name = Path;
-    while (*Path)
+    const size_t LastSlash = PathView.find_last_of("/\\");
+    if (LastSlash == std::string_view::npos)
     {
-        if (*Path == '/' || *Path == '\\')
-        {
-            Name = Path + 1;
-        }
-        Path++;
+        return PathView;
     }
-    return Name;
+    return PathView.substr(LastSlash + 1);
 }
 
 #define FILENAME GetFileName(__FILE__)
-#define UE_LOG(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, "[%s:%d] " Fmt, FILENAME, __LINE__, __VA_ARGS__)
+#define UE_LOG(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, "[%s:%d] " Fmt, FILENAME.data(), __LINE__, __VA_ARGS__)
 
 // TODO: 테스트 해야함
 #define UE_LOGFMT(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, std::format("[{}:{}] " Fmt, FILENAME, __LINE__, __VA_ARGS__))

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
@@ -152,7 +152,7 @@ private:
     template <typename T>
     auto ConvertIfFString(T&& Arg)
     {
-        if constexpr (std::same_as<T, FString>)
+        if constexpr (std::same_as<std::decay_t<T>, FString>)
         {
             return Arg.ToAnsiString();
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
@@ -21,7 +21,7 @@ static consteval std::string_view GetFileName(std::string_view PathView)
 #define UE_LOG(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, "[%s:%d] " Fmt, FILENAME.data(), __LINE__, __VA_ARGS__)
 
 // TODO: 테스트 해야함
-#define UE_LOGFMT(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, std::format("[{}:{}] " Fmt, FILENAME, __LINE__, __VA_ARGS__))
+#define UE_LOGFMT(Level, Fmt, ...) FConsole::GetInstance().AddLogFmt(Level, "[{}:{}] " Fmt, FILENAME, __LINE__, __VA_ARGS__)
 
 
 enum class ELogLevel : uint8
@@ -97,6 +97,28 @@ public:
     void AddLog(ELogLevel Level, const ANSICHAR* Fmt, ...);
     void AddLog(ELogLevel Level, const WIDECHAR* Fmt, ...);
     void AddLog(ELogLevel Level, const FString& Message);
+
+    template <typename... Args>
+    void AddLogFmt(ELogLevel Level, std::string_view Fmt, Args&&... Arguments)
+    {
+        // 1. 인자들을 변환하여 튜플에 저장
+        //    FString인 경우 ToAnsiString()의 결과(std::string)가 저장됨
+        //    변환된 std::string 객체들은 이 튜플 내에 실제 값으로 존재하게 되어 수명 문제 방지
+        std::tuple TransformedArgsTuple(ConvertIfFString(std::forward<Args>(Arguments))...);
+
+        // 2. 튜플에 저장된 인자들을 std::make_format_args 전달
+        //    std::apply를 사용하여 튜플의 요소들을 함수의 인자로 풀어줌
+        const auto FormatArgs = std::apply(
+            []<typename... InnerArgs>(InnerArgs&&... TransformedArgs)
+            {
+                return std::make_format_args(std::forward<InnerArgs>(TransformedArgs)...);
+            },
+            TransformedArgsTuple
+        );
+
+        AddLog(Level, std::vformat(Fmt, FormatArgs));
+    }
+
     void Draw();
     void ExecuteCommand(const std::string& Command);
     void OnResize(HWND hWnd);
@@ -110,6 +132,33 @@ public:
         else
         {
             bWasOpen = true;
+        }
+    }
+
+private:
+    /**
+     * 인자의 타입이 FString일 경우 ANSI 문자열(std::string)로 변환하고,
+     * 그 외의 경우에는 인자를 그대로 전달합니다.
+     *
+     * 이 메서드는 컴파일 타임에 인자의 타입이 FString과 일치하는지 검사합니다.
+     * 일치하는 경우 FString의 ToAnsiString 메서드를 호출하고,
+     * 그렇지 않은 경우 원본 인자를 수정 없이 전달합니다.
+     *
+     * @tparam T 전달되어 처리될 인자의 타입
+     * @param Arg FString 타입일 경우 변환될 인자, 그 외의 경우 그대로 전달될 인자
+     * @return 인자가 FString 타입인 경우 ANSI 문자열(std::string)을 반환하고,
+     *         그 외의 타입인 경우 원본 인자를 그대로 반환합니다.
+     */
+    template <typename T>
+    auto ConvertIfFString(T&& Arg)
+    {
+        if constexpr (std::same_as<T, FString>)
+        {
+            return Arg.ToAnsiString();
+        }
+        else
+        {
+            return std::forward<T>(Arg);
         }
     }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UserInterface/Console.h
@@ -25,7 +25,7 @@ static consteval const char* GetFileName(const char* Path)
 #define UE_LOG(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, "[%s:%d] " Fmt, FILENAME, __LINE__, __VA_ARGS__)
 
 // TODO: 테스트 해야함
-#define UE_LOG_FMT(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, std::format("[{}:{}] " Fmt, FILENAME, __LINE__, __VA_ARGS__))
+#define UE_LOGFMT(Level, Fmt, ...) FConsole::GetInstance().AddLog(Level, std::format("[{}:{}] " Fmt, FILENAME, __LINE__, __VA_ARGS__))
 
 
 enum class ELogLevel : uint8


### PR DESCRIPTION
## 변경 이유
오브젝트를 생성할 때는 ConstructObject에 의해 placement new를 이용해서 생성되지만, delete시 Object의 delete 오버로딩이 호출되는 문?제가 있었습니다.

LOGFMT는 `GetFileName()`을 가져올 때, 컴파일 타임에 포인터 연산으로 파일 이름만 가져오게 되는데, 연산과정중 문제가 생긴건지, std::format에서 에러가 자꾸 떠서 std::string_view를 이용하여 수정했습니다.

이참에 `FString`도 바로 `UE_LOGFMT`로 사용할 수 있도록 개선하였습니다.

## 주요 변경사항
- Rotator.h에 전역으로 선언되어있던 `operator*`를 `Rotator` 클래스 내부로 이동했습니다.
- Object에 있던 new, delete 연산자 오버로딩을 제거하였습니다.
- 메모리 할당 함수를 `AlignedMalloc`으로 변경하였습니다.
- 그 외 `ConstructorObject`와 `ProcessPendingDestroyObjects`의 오브젝트 생성 & 제거 로직을 개선하였습니다.