### PR TITLE
Add new particle init velocity module

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.cpp
@@ -504,6 +504,17 @@ FMatrix FMatrix::GetMatrixWithoutScale(float Tolerance) const
     return Result;
 }
 
+FVector4 FMatrix::TransformVector(const FVector& V) const
+{
+    return TransformFVector4(FVector4{V.X, V.Y, V.Z, 0.f});
+}
+
+FVector FMatrix::InverseTransformVector(const FVector& V) const
+{
+    const FMatrix InvSelf = Inverse(*this);
+    return InvSelf.TransformVector(V);
+}
+
 void FMatrix::RemoveScaling(float Tolerance)
 {
     const float SquareSum0 = (M[0][0] * M[0][0]) + (M[0][1] * M[0][1]) + (M[0][2] * M[0][2]);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.h
@@ -55,6 +55,15 @@ public:
 
     FMatrix GetMatrixWithoutScale(float Tolerance = SMALL_NUMBER) const;
 
+    FVector4 TransformVector(const FVector& V) const;
+
+    /**
+     *	이 매트릭스의 역행렬로 방향 벡터를 변환합니다. (위치 정보는 무시됨)
+     *	표면 노멀(또는 평면)을 변환하고 비균일 스케일링까지 올바르게 적용하려면
+     *	행렬 역행렬의 adjoint를 사용하는 TransformByUsingAdjointT를 사용하세요.
+     */
+    FVector InverseTransformVector(const FVector& V) const;
+
     void RemoveScaling(float Tolerance = SMALL_NUMBER);
 
     bool Equals(const FMatrix& Other, float Tolerance = KINDA_SMALL_NUMBER) const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Vector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Vector.h
@@ -104,7 +104,7 @@ public:
     explicit FVector(float Scalar) : X(Scalar), Y(Scalar), Z(Scalar) {}
 
     explicit FVector(const FRotator& InRotator);
-    explicit FVector(const FVector4& InVector4);
+    FVector(const FVector4& InVector4);
 
     // Vector(0, 0, 0)
     static const FVector ZeroVector;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloatUniform.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloatUniform.h
@@ -1,0 +1,58 @@
+﻿#pragma once
+#include "DistributionFloat.h"
+
+
+class UDistributionFloatUniform : public UDistributionFloat
+{
+    DECLARE_CLASS(UDistributionFloatUniform, UDistributionFloat)
+
+public:
+    UDistributionFloatUniform() = default;
+
+public:
+    /** Low end of output float distribution. */
+    UPROPERTY(
+        EditAnywhere,
+        float, Min, = 0.0f;
+    )
+
+    /** High end of output float distribution. */
+    UPROPERTY(
+        EditAnywhere,
+        float, Max, = 0.0f;
+    )
+
+public:
+    //~ Begin UObject Interface
+    virtual void PostInitProperties() override;
+    // virtual void PostLoad() override;
+    //~ End UObject Interface
+
+    //~ Begin UDistributionFloat Interface
+    virtual float GetValue(float F = 0.f, UObject* Data = nullptr, FRandomStream* InRandomStream = nullptr) const override;
+
+    //@todo.CONSOLE: Currently, consoles need this? At least until we have some sort of cooking/packaging step!
+    virtual ERawDistributionOperation GetOperation() const override;
+    virtual uint32 InitializeRawEntry(float Time, float* Values) const override;
+    //~ End UDistributionFloat Interface
+
+    //~ Begin FCurveEdInterface Interface
+    virtual int32 GetNumKeys() const override;
+    virtual int32 GetNumSubCurves() const override;
+    virtual FColor GetSubCurveButtonColor(int32 SubCurveIndex, bool bIsSubCurveHidden) const override;
+    virtual float GetKeyIn(int32 KeyIndex) override;
+    virtual float GetKeyOut(int32 SubIndex, int32 KeyIndex) override;
+    virtual FColor GetKeyColor(int32 SubIndex, int32 KeyIndex, const FColor& CurveColor) override;
+    virtual void GetInRange(float& MinIn, float& MaxIn) const override;
+    virtual void GetOutRange(float& MinOut, float& MaxOut) const override;
+    // virtual EInterpCurveMode GetKeyInterpMode(int32 KeyIndex) const override;
+    virtual void GetTangents(int32 SubIndex, int32 KeyIndex, float& ArriveTangent, float& LeaveTangent) const override;
+    virtual float EvalSub(int32 SubIndex, float InVal) override;
+    virtual int32 CreateNewKey(float KeyIn) override;
+    virtual void DeleteKey(int32 KeyIndex) override;
+    virtual int32 SetKeyIn(int32 KeyIndex, float NewInVal) override;
+    virtual void SetKeyOut(int32 SubIndex, int32 KeyIndex, float NewOutVal) override;
+    // virtual void SetKeyInterpMode(int32 KeyIndex, EInterpCurveMode NewMode) override;
+    virtual void SetTangents(int32 SubIndex, int32 KeyIndex, float ArriveTangent, float LeaveTangent) override;
+    //~ End FCurveEdInterface Interface
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
@@ -1665,7 +1665,7 @@ const FRawDistribution* FRawDistributionFloat::GetFastRawDistribution()
 {
     if (!IsSimple() || !HasLookupTable())
     {
-        return 0;
+        return nullptr;
     }
 
     // if we get here, we better have been initialized!

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocity.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocity.cpp
@@ -1,0 +1,80 @@
+﻿#include "ParticleModuleVelocity.h"
+
+#include "ParticleModuleRequired.h"
+#include "Components/ParticleSystemComponent.h"
+#include "Distributions/DistributionFloatUniform.h"
+#include "Distributions/DistributionVectorUniform.h"
+#include "Particles/ParticleEmitter.h"
+#include "Particles/ParticleEmitterInstances.h"
+#include "Particles/ParticleHelper.h"
+#include "Particles/ParticleLODLevel.h"
+#include "UObject/ObjectFactory.h"
+
+UParticleModuleVelocity::UParticleModuleVelocity()
+{
+    bSpawnModule = true;
+}
+
+void UParticleModuleVelocity::InitializeDefaults()
+{
+    if (!StartVelocity.IsCreated())
+    {
+        StartVelocity.Distribution = FObjectFactory::ConstructObject<UDistributionVectorUniform>(this, TEXT("DistributionStartVelocity"));
+    }
+
+    if (!StartVelocityRadial.IsCreated())
+    {
+        StartVelocityRadial.Distribution = FObjectFactory::ConstructObject<UDistributionFloatUniform>(this, TEXT("DistributionStartVelocityRadial"));
+    }
+}
+
+void UParticleModuleVelocity::PostInitProperties()
+{
+    Super::PostInitProperties();
+    InitializeDefaults();
+}
+
+void UParticleModuleVelocity::Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase)
+{
+    // SpawnEx(Owner, Offset, SpawnTime, &GetRandomStream(Owner), ParticleBase);
+    SpawnEx(Owner, Offset, SpawnTime, nullptr, ParticleBase);
+}
+
+void UParticleModuleVelocity::SpawnEx(
+    FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FRandomStream* InRandomStream, FBaseParticle* ParticleBase
+)
+{
+    SPAWN_INIT
+    {
+        FVector Vel = StartVelocity.GetValue(Owner->EmitterTime, Owner->Component, 0, InRandomStream);
+        FVector FromOrigin = (Particle.Location - Owner->EmitterToSimulation.GetOrigin()).GetSafeNormal();
+
+        FVector OwnerScale(1.0f);
+        if ((bApplyOwnerScale == true) && Owner->Component)
+        {
+            OwnerScale = Owner->Component->GetComponentTransform().GetScale3D();
+        }
+
+        UParticleLODLevel* LODLevel = Owner->SpriteTemplate->GetCurrentLODLevel(Owner);
+        assert(LODLevel);
+        if (LODLevel->RequiredModule->bUseLocalSpace)
+        {
+            if (bInWorldSpace == true)
+            {
+                Vel = Owner->SimulationToWorld.InverseTransformVector(Vel);
+            }
+            else
+            {
+                Vel = Owner->EmitterToSimulation.TransformVector(Vel);
+            }
+        }
+        else if (bInWorldSpace == false)
+        {
+            Vel = Owner->EmitterToSimulation.TransformVector(Vel);
+        }
+        Vel *= OwnerScale;
+        Vel += FromOrigin * StartVelocityRadial.GetValue(Owner->EmitterTime, Owner->Component, InRandomStream) * OwnerScale;
+        Particle.Velocity += Vel;
+        Particle.BaseVelocity += Vel;
+    }
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocity.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocity.h
@@ -1,0 +1,58 @@
+﻿#pragma once
+#include "ParticleModuleVelocityBase.h"
+#include "Distributions/DistributionFloat.h"
+#include "Distributions/DistributionVector.h"
+
+
+class UParticleModuleVelocity : public UParticleModuleVelocityBase
+{
+    DECLARE_CLASS(UParticleModuleVelocity, UParticleModuleVelocityBase)
+
+public:
+    UParticleModuleVelocity();
+    virtual ~UParticleModuleVelocity() override = default;
+
+    /** 
+     *	The velocity to apply to a particle when it is spawned.
+     *	Value is retrieved using the EmitterTime of the emitter.
+     */
+    UPROPERTY(
+        EditAnywhere,
+        FRawDistributionVector, StartVelocity, {};
+    )
+
+    /** 
+     *	The velocity to apply to a particle along its radial direction.
+     *	Direction is determined by subtracting the location of the emitter from the particle location at spawn.
+     *	Value is retrieved using the EmitterTime of the emitter.
+     */
+    UPROPERTY(
+        EditAnywhere,
+        FRawDistributionFloat, StartVelocityRadial, {}
+    )
+
+public:
+    /** Initializes the default values for this property */
+    void InitializeDefaults();
+
+    //~ Begin UObject Interface
+#if WITH_EDITOR
+    // virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif // WITH_EDITOR
+    virtual void PostInitProperties() override;
+    //~ End UObject Interface
+
+    //~ Begin UParticleModule Interface
+    virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
+    //~ Begin UParticleModule Interface
+
+    /**
+     *	Extended version of spawn, allows for using a random stream for distribution value retrieval
+     *
+     *	@param	Owner				The particle emitter instance that is spawning
+     *	@param	Offset				The offset to the modules payload data
+     *	@param	SpawnTime			The time of the spawn
+     *	@param	InRandomStream		The random stream to use for retrieving random values
+     */
+    void SpawnEx(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, struct FRandomStream* InRandomStream, FBaseParticle* ParticleBase);
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocity.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocity.h
@@ -44,7 +44,7 @@ public:
 
     //~ Begin UParticleModule Interface
     virtual void Spawn(FParticleEmitterInstance* Owner, int32 Offset, float SpawnTime, FBaseParticle* ParticleBase) override;
-    //~ Begin UParticleModule Interface
+    //~ End UParticleModule Interface
 
     /**
      *	Extended version of spawn, allows for using a random stream for distribution value retrieval

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocityBase.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocityBase.cpp
@@ -1,0 +1,1 @@
+﻿#include "ParticleModuleVelocityBase.h"

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocityBase.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules/ParticleModuleVelocityBase.h
@@ -1,0 +1,30 @@
+﻿#pragma once
+#include "ParticleModule.h"
+
+
+class UParticleModuleVelocityBase : public UParticleModule
+{
+    DECLARE_CLASS(UParticleModuleVelocityBase, UParticleModule)
+
+public:
+    UParticleModuleVelocityBase() = default;
+    virtual ~UParticleModuleVelocityBase() override = default;
+
+public:
+    /**
+     *	If true, then treat the velocity as world-space defined.
+     *	NOTE: LocalSpace emitters that are moving will see strange results...
+     */
+    UPROPERTY_WITH_FLAGS(
+        EditAnywhere,
+        bool, bInWorldSpace
+        // uint32 bInWorldSpace : 1;
+    )
+
+    /** If true, then apply the particle system components scale to the velocity value. */
+    UPROPERTY_WITH_FLAGS(
+        EditAnywhere,
+        bool, bApplyOwnerScale
+        // uint32 bApplyOwnerScale : 1;
+    )
+};

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -315,7 +315,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Components\Light\SpotLightComponent.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Components\Material\Material.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Components\MeshComponent.cpp" />
-      <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Distributions\Distributions.cpp"/>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Distributions\Distributions.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Engine\StaticMesh.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Components\ParticleSubUVComponent.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Components\PrimitiveComponent.cpp" />
@@ -674,6 +674,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Components\MeshComponent.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Distributions\Distribution.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Distributions\DistributionFloat.h"/>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Distributions\DistributionFloatUniform.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Distributions\Distributions.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Distributions\DistributionVector.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Distributions\DistributionVectorUniform.h"/>

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -359,6 +359,8 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleTypeDataBase.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuletypeDataMesh.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleLifetime.cpp" />
+      <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleVelocity.cpp"/>
+      <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleVelocityBase.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSpriteEmitter.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\ReferenceSkeleton.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\UnrealClient.cpp" />
@@ -730,6 +732,8 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleTypeDataBase.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuletypeDataMesh.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleLifetime.h" />
+      <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleVelocity.h"/>
+      <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleVelocityBase.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSpriteEmitter.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystem.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleRequired.h" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -352,8 +352,8 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleLODLevel.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModule.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleRequired.cpp" />
-      <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSize.cpp"/>
-      <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSizeBase.cpp"/>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSize.cpp"/>
+    <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSizeBase.cpp"/>
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSpawn.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSpawnPerUnit.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleTypeDataBase.cpp" />
@@ -721,8 +721,8 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleHelper.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleLODLevel.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModule.h" />
-      <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSize.h"/>
-      <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSizeBase.h"/>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSize.h"/>
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSizeBase.h"/>
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSpawn.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSpawnBase.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModules\ParticleModuleSpawnPerUnit.h" />


### PR DESCRIPTION
## 주요 변경사항
> 아래 내용은 AI가 요약하였습니다.
- `ParticleModuleVelocity` 및 `ParticleModuleVelocityBase` 클래스 추가 및 vcxproj 파일에 포함
- `FMatrix` 클래스에 `TransformVector`, `InverseTransformVector` 함수 추가
- `FVector4` 파라미터를 받는 `FVector` 생성자에서 `explicit` 키워드 제거
- `DistributionFloatUniform` 클래스 및 관련 로직 구현
- 불필요한 들여쓰기를 수정하여 코드 정리