### PR TITLE
Fix: Distribution 수정 및 가독성 개선

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloat.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloat.h
@@ -20,7 +20,7 @@ private:
 
 public:
     UPROPERTY_WITH_FLAGS(
-        EditAnywhere,
+        EditAnywhere | EditInline,
         UDistributionFloat*, Distribution
     )
 
@@ -95,7 +95,7 @@ public:
     /** Can this variable be baked out to a FRawDistribution? Should be true 99% of the time*/
     UPROPERTY_WITH_FLAGS(
         EditAnywhere,
-        bool, bCanBeBaked
+        bool, bCanBeBaked, = true;
         // uint8 bCanBeBaked : 1;
     )
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloat.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloat.h
@@ -172,7 +172,7 @@ public:
 
     /** Begin UObject interface */
 #if	WITH_EDITOR
-    // virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+    virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif	// WITH_EDITOR
     // virtual bool NeedsLoadForClient() const override;
     // virtual bool NeedsLoadForServer() const override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloat.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionFloat.h
@@ -32,6 +32,8 @@ public:
     {
     }
 
+    virtual ~FRawDistributionFloat();
+
     /** Whether the distribution data has been cooked or the object itself is available */
     bool IsCreated();
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
@@ -7,12 +7,11 @@ class UDistributionVector;
 
 enum class EDistributionVectorLockFlags : uint8
 {
-    EDVLF_None,
-    EDVLF_XY,
-    EDVLF_XZ,
-    EDVLF_YZ,
-    EDVLF_XYZ,
-    EDVLF_MAX,
+    None,
+    XY,
+    XZ,
+    YZ,
+    XYZ,
 };
 
 struct FRawDistributionVector : public FRawDistribution

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
@@ -192,7 +192,7 @@ public:
 
     /** Begin UObject interface */
 #if	WITH_EDITOR
-    // virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+    virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif // WITH_EDITOR
     // virtual bool NeedsLoadForClient() const override;
     // virtual bool NeedsLoadForServer() const override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
@@ -33,7 +33,7 @@ private:
 
 public:
     UPROPERTY_WITH_FLAGS(
-        EditAnywhere,
+        EditAnywhere | EditInline,
         UDistributionVector*, Distribution
     )
 
@@ -114,7 +114,7 @@ public:
     /** Can this variable be baked out to a FRawDistribution? Should be true 99% of the time*/
     UPROPERTY_WITH_FLAGS(
         EditAnywhere,
-        bool, bCanBeBaked
+        bool, bCanBeBaked, = true;
         // uint8 bCanBeBaked : 1;
     )
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVector.h
@@ -49,6 +49,7 @@ public:
     {
     }
 
+    virtual ~FRawDistributionVector();
 
 #if WITH_EDITOR
     /**

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVectorUniform.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/DistributionVectorUniform.h
@@ -14,23 +14,23 @@ public:
     /** Upper end of FVector magnitude range. */
     UPROPERTY_WITH_FLAGS(
         EditAnywhere,
-        FVector, Max
+        FVector, Max, = FVector::OneVector;
     )
 
     /** Lower end of FVector magnitude range. */
     UPROPERTY_WITH_FLAGS(
         EditAnywhere,
-        FVector, Min
+        FVector, Min, = FVector::OneVector;
     )
 
     UPROPERTY_WITH_FLAGS(
         EditAnywhere,
-        EDistributionVectorLockFlags, LockedAxes
+        EDistributionVectorLockFlags, LockedAxes, = EDistributionVectorLockFlags::None;
     )
 
     UPROPERTY_WITH_FLAGS(
         EditAnywhere,
-        bool, bUseExtremes
+        bool, bUseExtremes, = false;
     )
 
 public:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
@@ -853,6 +853,14 @@ bool FRawDistributionVector::IsCreated()
 }
 
 #if WITH_EDITOR
+FRawDistributionVector::~FRawDistributionVector()
+{
+    if (IsValid(Distribution))
+    {
+        Distribution->MarkAsGarbage();
+    }
+}
+
 void FRawDistributionVector::Initialize()
 {
     // Nothing to do if we don't have a distribution.
@@ -1599,6 +1607,14 @@ void UDistributionVectorUniform::SetTangents(int32 SubIndex, int32 KeyIndex, flo
 float UDistributionFloat::GetValue(float F, UObject* Data, struct FRandomStream* InRandomStream) const
 {
     return 0.0;
+}
+
+FRawDistributionFloat::~FRawDistributionFloat()
+{
+    if (IsValid(Distribution))
+    {
+        Distribution->MarkAsGarbage();
+    }
 }
 
 bool FRawDistributionFloat::IsCreated()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
@@ -797,16 +797,16 @@ void FRawDistribution::GetValue3Random(float Time, float* InValue, FRandomStream
     RandValues[2] = DIST_GET_RANDOM_VALUE(InRandomStream);
     switch (static_cast<EDistributionVectorLockFlags>(LookupTable.LockFlag))
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
+    case EDistributionVectorLockFlags::XY:
         RandValues.Y = RandValues.X;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XZ:
+    case EDistributionVectorLockFlags::XZ:
         RandValues.Z = RandValues.X;
         break;
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::YZ:
         RandValues.Z = RandValues.Y;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         RandValues.Y = RandValues.X;
         RandValues.Z = RandValues.X;
         break;
@@ -1064,7 +1064,7 @@ FVector UDistributionVectorUniform::GetValue(float F, UObject* Data, int32 Extre
 
     switch (LockedAxes)
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
+    case EDistributionVectorLockFlags::XY:
         if (bUseExtremes)
         {
             if (bMin)
@@ -1085,7 +1085,7 @@ FVector UDistributionVectorUniform::GetValue(float F, UObject* Data, int32 Extre
         }
         fY = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XZ:
+    case EDistributionVectorLockFlags::XZ:
         if (bUseExtremes)
         {
             if (bMin)
@@ -1106,7 +1106,7 @@ FVector UDistributionVectorUniform::GetValue(float F, UObject* Data, int32 Extre
         }
         fZ = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::YZ:
         if (bUseExtremes)
         {
             if (bMin)
@@ -1127,7 +1127,7 @@ FVector UDistributionVectorUniform::GetValue(float F, UObject* Data, int32 Extre
         }
         fZ = fY;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         if (bUseExtremes)
         {
             if (bMin)
@@ -1146,7 +1146,7 @@ FVector UDistributionVectorUniform::GetValue(float F, UObject* Data, int32 Extre
         fY = fX;
         fZ = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_None:
+    case EDistributionVectorLockFlags::None:
     default:
         if (bUseExtremes)
         {
@@ -1235,27 +1235,27 @@ FVector UDistributionVectorUniform::GetMinValue() const
 
     switch (LockedAxes)
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
+    case EDistributionVectorLockFlags::XY:
         fX = LocalMin.X;
         fY = LocalMin.X;
         fZ = LocalMin.Z;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XZ:
+    case EDistributionVectorLockFlags::XZ:
         fX = LocalMin.X;
         fY = LocalMin.Y;
         fZ = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::YZ:
         fX = LocalMin.X;
         fY = LocalMin.Y;
         fZ = fY;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         fX = LocalMin.X;
         fY = fX;
         fZ = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_None:
+    case EDistributionVectorLockFlags::None:
     default:
         fX = LocalMin.X;
         fY = LocalMin.Y;
@@ -1276,27 +1276,27 @@ FVector UDistributionVectorUniform::GetMaxValue() const
 
     switch (LockedAxes)
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
+    case EDistributionVectorLockFlags::XY:
         fX = LocalMax.X;
         fY = LocalMax.X;
         fZ = LocalMax.Z;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XZ:
+    case EDistributionVectorLockFlags::XZ:
         fX = LocalMax.X;
         fY = LocalMax.Y;
         fZ = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::YZ:
         fX = LocalMax.X;
         fY = LocalMax.Y;
         fZ = fY;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         fX = LocalMax.X;
         fY = fX;
         fZ = fX;
         break;
-    case EDistributionVectorLockFlags::EDVLF_None:
+    case EDistributionVectorLockFlags::None:
     default:
         fX = LocalMax.X;
         fY = LocalMax.Y;
@@ -1316,11 +1316,11 @@ int32 UDistributionVectorUniform::GetNumSubCurves() const
 {
     switch (LockedAxes)
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
-    case EDistributionVectorLockFlags::EDVLF_XZ:
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::XY:
+    case EDistributionVectorLockFlags::XZ:
+    case EDistributionVectorLockFlags::YZ:
         return 4;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         return 2;
     }
     return 6;
@@ -1416,20 +1416,20 @@ float UDistributionVectorUniform::GetKeyOut(int32 SubIndex, int32 KeyIndex)
 
     switch (LockedAxes)
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
+    case EDistributionVectorLockFlags::XY:
         LocalMin.Y = LocalMin.X;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XZ:
+    case EDistributionVectorLockFlags::XZ:
         LocalMin.Z = LocalMin.X;
         break;
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::YZ:
         LocalMin.Z = LocalMin.Y;
         break;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         LocalMin.Y = LocalMin.X;
         LocalMin.Z = LocalMin.X;
         break;
-    case EDistributionVectorLockFlags::EDVLF_None:
+    case EDistributionVectorLockFlags::None:
     default:
         break;
     }
@@ -1503,24 +1503,23 @@ void UDistributionVectorUniform::GetOutRange(float& MinOut, float& MaxOut) const
 
     switch (LockedAxes)
     {
-    case EDistributionVectorLockFlags::EDVLF_XY:
+    case EDistributionVectorLockFlags::XY:
         LocalMin2 = FVector(LocalMin.X, LocalMin.X, LocalMin.Z);
         LocalMax2 = FVector(LocalMax.X, LocalMax.X, LocalMax.Z);
         break;
-    case EDistributionVectorLockFlags::EDVLF_XZ:
+    case EDistributionVectorLockFlags::XZ:
         LocalMin2 = FVector(LocalMin.X, LocalMin.Y, LocalMin.X);
         LocalMax2 = FVector(LocalMax.X, LocalMax.Y, LocalMax.X);
         break;
-    case EDistributionVectorLockFlags::EDVLF_YZ:
+    case EDistributionVectorLockFlags::YZ:
         LocalMin2 = FVector(LocalMin.X, LocalMin.Y, LocalMin.Y);
         LocalMax2 = FVector(LocalMax.X, LocalMax.Y, LocalMax.Y);
         break;
-    case EDistributionVectorLockFlags::EDVLF_XYZ:
+    case EDistributionVectorLockFlags::XYZ:
         LocalMin2 = FVector(LocalMin.X);
         LocalMax2 = FVector(LocalMax.X);
         break;
-    case EDistributionVectorLockFlags::EDVLF_None:
-    default:
+    case EDistributionVectorLockFlags::None:
         LocalMin2 = FVector(LocalMin.X, LocalMin.Y, LocalMin.Z);
         LocalMax2 = FVector(LocalMax.X, LocalMax.Y, LocalMax.Z);
         break;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Distributions/Distributions.cpp
@@ -1029,6 +1029,12 @@ void UDistributionVector::GetRange(FVector& OutMin, FVector& OutMax) const
     OutMax = FVector::ZeroVector;
 }
 
+void UDistributionVector::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+    Super::PostEditChangeProperty(PropertyChangedEvent);
+    bIsDirty = true;
+}
+
 void UDistributionVectorUniform::PostInitProperties()
 {
     Super::PostInitProperties();
@@ -1752,6 +1758,12 @@ void UDistributionFloat::GetOutRange(float& MinOut, float& MaxOut) const
 {
     MinOut = 0.0f;
     MaxOut = 0.0f;
+}
+
+void UDistributionFloat::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+    Super::PostEditChangeProperty(PropertyChangedEvent);
+    bIsDirty = true;
 }
 
 uint32 UDistributionFloat::InitializeRawEntry(float Time, float* Values) const


### PR DESCRIPTION
**주요 변경사항**

- `DistributionFloat`와 `DistributionVector`에서 UPROPERTY 플래그 관련 문제를 수정하고, 기본값을 설정했습니다.
- `PostEditChangeProperty` 함수를 활성화하고, `bIsDirty` 설정을 추가했습니다.
- `Distribution` 클래스에 소멸자를 추가하고 메모리 정리 코드를 개선했습니다.
- 가독성을 높이기 위해 `EDistributionVectorLockFlags`에서 불필요한 `EDVLF` 접두사를 제거했습니다.
- `DistributionVectorUniform`에서 초기값을 명시적으로 추가하여 코드의 가독성을 향상시켰습니다.